### PR TITLE
model wrong name in portal chat

### DIFF
--- a/gateway.py
+++ b/gateway.py
@@ -340,6 +340,22 @@ def _resolve_model_id(model: str) -> str:
         # local display name. If neither is set, return "unknown" so audit rows
         # are queryable rather than carrying an empty string.
         return CLAUDE_PRIMARY_MODEL or LOCAL_LLM_MODEL_NAME or "unknown"
+    _stripped = model.strip()
+    # A BARE display constant carries no embedded model ID — the parentheses are
+    # part of the NAME. model_router._tier_label() returns LOCAL_LLM_DISPLAY
+    # unadorned whenever the local catalog is empty (no model discovered), and
+    # the wrapper regex below then read "Local (In-house)" as the ID "In-house",
+    # inventing a model that exists nowhere and writing it to the chat footer and
+    # to model_usages.model. Recognise those names first and pass them through.
+    # Labels that DO carry an ID ("Local (In-house) (llama-guard3:1b)") are not
+    # matched here and still resolve via the regex, since it anchors on the LAST
+    # parenthesised group.
+    try:
+        from core.model_registry import LOCAL_LLM_DISPLAY as _LOCAL_DISPLAY
+        if _stripped == (_LOCAL_DISPLAY or "").strip():
+            return _stripped
+    except Exception:
+        pass
     # Strip display-label wrapper: "Display Name (model-id)" → "model-id"
     import re as _re
     m = _re.search(r'\(([^)]+)\)\s*(?:\[[^\]]*\])?\s*$', model)
@@ -7468,6 +7484,11 @@ async def ask_ai(q: Question, request: Request, authorization: Optional[str] = _
                 # in_tok=3 for every turn after a transient failure.
                 _stream_meta: dict = {}
                 _stream_thinking = ""
+                # True only once the ainxt-api hop has actually STREAMED this
+                # turn's answer. `_ainxt_model` is bound before the ainxt-api
+                # try block, so its mere existence says nothing about who
+                # served the response — see the _gmeta["model"] resolution below.
+                _ainxt_served = False
                 # /ask has already run compliance_engine.validate_input() on
                 # `original` at line 1799 (_ask_chk). The OpenAI/Gemini gateways
                 # used to re-validate the LAST message of _fp_messages — which
@@ -7904,6 +7925,10 @@ async def ask_ai(q: Question, request: Request, authorization: Optional[str] = _
                     # Populate _gmeta with the model used so chat_messages.model_used
                     # is saved correctly (otherwise it stays "auto" from the initializer).
                     _gmeta["model"] = _ainxt_model
+                    # Reached only when ainxt-api streamed the answer itself. The
+                    # post-stream metadata block below keys off this rather than
+                    # off `_ainxt_model` being bound.
+                    _ainxt_served = True
 
                     # Success marker. Without this the happy path is silent and
                     # indistinguishable from a turn that quietly produced nothing,
@@ -8063,7 +8088,17 @@ async def ask_ai(q: Question, request: Request, authorization: Optional[str] = _
                 # is absent (in_tok=0), estimate from prompt char count rather
                 # than reading a potentially stale thread-local.
                 # Prefer: ainxt-api model > stream_meta sentinel > router thread-local > "auto"
-                _ainxt_model_used = locals().get("_ainxt_model", "")
+                #
+                # The preference is valid ONLY when ainxt-api actually served this
+                # turn. `_ainxt_model` is assigned before the ainxt-api try block
+                # (the user's picked model, verbatim), so it stays bound even when
+                # that hop raises — disabled, unreachable, or no AINXT_API_URL — and
+                # the `except` falls back to _mr.async_stream(). Keying off
+                # locals() therefore pinned the footer to the PICKED model and
+                # discarded the real one from _stream_meta, so a turn that fell
+                # back to Claude still reported whatever the user had selected.
+                # _ainxt_served is set only on the ainxt-api streaming success path.
+                _ainxt_model_used = locals().get("_ainxt_model", "") if _ainxt_served else ""
                 _gmeta["model"]   = (
                     _ainxt_model_used
                     or _resolve_model_id(_stream_meta.get("model_id") or _stream_meta.get("model_label") or getattr(_mr, "last_model_id", None) or getattr(_mr, "last_model_label", ""))

--- a/gateway_local_llm.py
+++ b/gateway_local_llm.py
@@ -261,7 +261,16 @@ class _ModelCatalog:
             )
             r.raise_for_status()
             data = r.json()
-            raw_ids   = [item["id"] for item in data.get("data", [])]
+            # An OpenAI-compatible server with nothing loaded may answer 200 with
+            # {"object":"list","data":null} (Ollama does exactly this when no model
+            # has been pulled). The key EXISTS with a null value, so .get("data", [])
+            # returns None, not the default — iterating it raised TypeError, which the
+            # blanket `except` below reported as "model discovery failed" and left the
+            # purpose-built "returned empty list" warning underneath unreachable.
+            # `or []` covers null/missing/empty alike; item.get("id") tolerates a
+            # malformed entry instead of KeyError-ing the whole catalog away.
+            _entries  = data.get("data") if isinstance(data, dict) else None
+            raw_ids   = [i.get("id") for i in (_entries or []) if isinstance(i, dict) and i.get("id")]
             model_ids = [m for m in raw_ids if _is_ui_model(m)]
             if raw_ids and not model_ids:
                 logger.warning(

--- a/models/model_router.py
+++ b/models/model_router.py
@@ -2992,6 +2992,13 @@ class ModelRouter:
             import contextvars as _cv
             _ctx_snapshot = _cv.copy_context()
 
+            # Marker used to ship the post-dispatch label back across the
+            # thread boundary — see _LabelHandoff below.
+            class _LabelHandoff:
+                __slots__ = ("label", "tier")
+                def __init__(self, label, tier):
+                    self.label, self.tier = label, tier
+
             def _run_sync():
                 def _inner():
                     try:
@@ -3006,6 +3013,37 @@ class ModelRouter:
                     except Exception as _e:
                         _loop.call_soon_threadsafe(_queue.put_nowait, _e)
                     finally:
+                        # last_model_label is a threading.local() property
+                        # (see ModelRouter._tl). _dispatch_stream runs HERE, on
+                        # this worker thread, so any label the _try_*_stream
+                        # helpers write — notably the Claude "[fallback]" label
+                        # when the selected provider's gateway is unavailable —
+                        # lands in THIS thread's storage and is invisible to the
+                        # event-loop thread that emits the __stream_meta__
+                        # sentinel below. That thread still holds the label set
+                        # from `decision.model` before dispatch, so a turn that
+                        # fell back to Claude was reported (and priced) as the
+                        # originally selected model. contextvars are copied into
+                        # this thread by _ctx_snapshot, but thread-locals are
+                        # not, and neither propagates back out — so hand the
+                        # value across the queue explicitly.
+                        try:
+                            # Read the RAW thread-locals, not the properties:
+                            # last_model_label/last_tier default to "auto" when
+                            # unset, which is indistinguishable from a value the
+                            # dispatch actually chose. A helper that never
+                            # touched them (no fallback taken) must hand back
+                            # None so the event-loop thread keeps the label and
+                            # tier it already holds from the routing decision.
+                            _loop.call_soon_threadsafe(
+                                _queue.put_nowait,
+                                _LabelHandoff(
+                                    getattr(self._tl, "last_model_label", None),
+                                    getattr(self._tl, "last_tier", None),
+                                ),
+                            )
+                        except Exception:
+                            pass
                         _loop.call_soon_threadsafe(_queue.put_nowait, _SENTINEL)
                 _ctx_snapshot.run(_inner)
 
@@ -3018,6 +3056,15 @@ class ModelRouter:
                     break
                 if isinstance(item, Exception):
                     raise item
+                if isinstance(item, _LabelHandoff):
+                    # Adopt the label the dispatch thread actually served under,
+                    # onto THIS thread, so the sentinel below reports the real
+                    # model rather than the pre-dispatch routing decision.
+                    if item.label:
+                        self.last_model_label = item.label
+                    if item.tier:
+                        self.last_tier = item.tier
+                    continue
                 yield item
             self._propagate_tokens(decision.tier)
 


### PR DESCRIPTION
(cherry picked from commit 40a53162ba10ea2f6657a74aafb87f1a866c98ab)

> **Before you spend time on this:** external pull requests are **not currently
> accepted or triaged**. Contributions are not open yet — see
> [CONTRIBUTING.md](../CONTRIBUTING.md). This template documents the workflow the
> maintaining team follows, and the one external contributions will follow once
> they open.

## What this changes

<!-- One paragraph. What behaviour is different after this PR? -->

## Why

<!-- Link the related issue, e.g. `Closes #123`. -->

## How it was verified

<!-- Commands you ran and what they reported. "Tests pass" on its own is not
     verification — say which tests, and on what platform. -->

```
(commands and output)
```

## Checklist

- [ ] Linked the related issue
- [ ] `ruff format` and `ruff check` clean (Python); lint clean (Node, if touched)
- [ ] Tests added or updated for the behaviour that changed
- [ ] Documentation updated if a setting or user-facing behaviour changed
- [ ] Requested review from the relevant owners in `CODEOWNERS`

### Configurability — required for every change

- [ ] No hardcoded hostnames, URLs, organisation names, credentials, or model identifiers
- [ ] Anything deployment-specific reads from an environment variable or config file,
      **and is documented in `.env.example`**
- [ ] Any new setting has a default that preserves existing behaviour
- [ ] Any new external service is optional — the platform still starts without it

### Privacy and security

- [ ] No secrets, tokens, internal hostnames, or personal data in code, tests,
      fixtures, or logs
- [ ] If this changes what personal data is stored, where it goes, or how long it is
      kept, say so explicitly here — it may need a privacy review
- [ ] New outbound network calls are named below, with their destination

## Notes for reviewers

<!-- Anything hard to see from the diff: a decision and the alternatives you rejected,
     a known limitation, follow-up work. -->
